### PR TITLE
fix(race condition): test for animation occurring without timeout

### DIFF
--- a/dist/commonjs/aurelia-animator-css.js
+++ b/dist/commonjs/aurelia-animator-css.js
@@ -13,33 +13,18 @@ var CssAnimator = (function () {
   function CssAnimator() {
     _classCallCheck(this, CssAnimator);
 
-    this.animationStack = [];
-
     this.useAnimationDoneClasses = false;
     this.animationEnteredClass = 'au-entered';
     this.animationLeftClass = 'au-left';
     this.isAnimating = false;
 
-    this.animationTimeout = 50;
+    this.verifyKeyframesExist = true;
   }
 
   CssAnimator.prototype._addMultipleEventListener = function _addMultipleEventListener(el, s, fn) {
     var evts = s.split(' ');
     for (var i = 0, ii = evts.length; i < ii; ++i) {
       el.addEventListener(evts[i], fn, false);
-    }
-  };
-
-  CssAnimator.prototype._addAnimationToStack = function _addAnimationToStack(animId) {
-    if (this.animationStack.indexOf(animId) < 0) {
-      this.animationStack.push(animId);
-    }
-  };
-
-  CssAnimator.prototype._removeAnimationFromStack = function _removeAnimationFromStack(animId) {
-    var idx = this.animationStack.indexOf(animId);
-    if (idx > -1) {
-      this.animationStack.splice(idx, 1);
     }
   };
 
@@ -62,6 +47,24 @@ var CssAnimator = (function () {
     delay = Number(delay.replace(/[^\d\.]/g, ''));
 
     return delay * 1000;
+  };
+
+  CssAnimator.prototype._getElementAnimationNames = function _getElementAnimationNames(element) {
+    var styl = _aureliaPal.DOM.getComputedStyle(element);
+    var prefix = undefined;
+
+    if (styl.getPropertyValue('animation-name')) {
+      prefix = '';
+    } else if (styl.getPropertyValue('-webkit-animation-name')) {
+      prefix = '-webkit-';
+    } else if (styl.getPropertyValue('-moz-animation-name')) {
+      prefix = '-moz-';
+    } else {
+      return [];
+    }
+
+    var animationNames = styl.getPropertyValue(prefix + 'animation-name');
+    return animationNames ? animationNames.split(' ') : [];
   };
 
   CssAnimator.prototype._performSingleAnimate = function _performSingleAnimate(element, className) {
@@ -87,6 +90,37 @@ var CssAnimator = (function () {
   CssAnimator.prototype._triggerDOMEvent = function _triggerDOMEvent(eventType, element) {
     var evt = _aureliaPal.DOM.createCustomEvent(eventType, { bubbles: true, cancelable: true, detail: element });
     _aureliaPal.DOM.dispatchEvent(evt);
+  };
+
+  CssAnimator.prototype._animationChangeWithValidKeyframe = function _animationChangeWithValidKeyframe(animationNames, prevAnimationNames) {
+    var newAnimationNames = animationNames.filter(function (name) {
+      return prevAnimationNames.indexOf(name) === -1;
+    });
+
+    if (newAnimationNames.length === 0) {
+      return false;
+    }
+
+    if (!this.verifyKeyframesExist) {
+      return true;
+    }
+
+    var keyframesRuleType = window.CSSRule.KEYFRAMES_RULE || window.CSSRule.MOZ_KEYFRAMES_RULE || window.CSSRule.WEBKIT_KEYFRAMES_RULE;
+
+    var styleSheets = document.styleSheets;
+    for (var i = 0; i < styleSheets.length; ++i) {
+      var cssRules = styleSheets[i].cssRules;
+
+      for (var j = 0; j < cssRules.length; ++j) {
+        var cssRule = cssRules[j];
+
+        if (cssRule.type === keyframesRuleType) {
+          if (newAnimationNames.indexOf(cssRule.name) !== -1) return true;
+        }
+      }
+    }
+
+    return false;
   };
 
   CssAnimator.prototype.animate = function animate(element, className) {
@@ -130,6 +164,7 @@ var CssAnimator = (function () {
       }
 
       classList.add('au-enter');
+      var prevAnimationNames = _this4._getElementAnimationNames(element);
 
       var animStart = undefined;
       _this4._addMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart = function (evAnimStart) {
@@ -139,16 +174,12 @@ var CssAnimator = (function () {
 
         evAnimStart.stopPropagation();
 
-        _this4._addAnimationToStack(animId);
-
         var animEnd = undefined;
         _this4._addMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd = function (evAnimEnd) {
           evAnimEnd.stopPropagation();
 
           classList.remove('au-enter-active');
           classList.remove('au-enter');
-
-          _this4._removeAnimationFromStack(animId);
 
           evAnimEnd.target.removeEventListener(evAnimEnd.type, animEnd);
 
@@ -168,6 +199,16 @@ var CssAnimator = (function () {
       var parent = element.parentElement;
       var delay = 0;
 
+      var cleanupAnimation = function cleanupAnimation() {
+        var animationNames = _this4._getElementAnimationNames(element);
+        if (!_this4._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
+          classList.remove('au-enter-active');
+          classList.remove('au-enter');
+          _this4._triggerDOMEvent(_aureliaTemplating.animationEvent.enterTimeout, element);
+          resolve(false);
+        }
+      };
+
       if (parent !== null && parent !== undefined && (parent.classList.contains('au-stagger') || parent.classList.contains('au-stagger-enter'))) {
         var elemPos = Array.prototype.indexOf.call(parent.childNodes, element);
         delay = _this4._getElementAnimationDelay(parent) * elemPos;
@@ -176,21 +217,12 @@ var CssAnimator = (function () {
 
         setTimeout(function () {
           classList.add('au-enter-active');
+          cleanupAnimation();
         }, delay);
       } else {
         classList.add('au-enter-active');
+        cleanupAnimation();
       }
-
-      setTimeout(function () {
-        if (_this4.animationStack.indexOf(animId) < 0) {
-          classList.remove('au-enter-active');
-          classList.remove('au-enter');
-
-          _this4._triggerDOMEvent(_aureliaTemplating.animationEvent.enterTimeout, element);
-
-          resolve(false);
-        }
-      }, _this4._getElementAnimationDelay(element) + _this4.animationTimeout + delay);
     });
   };
 
@@ -209,6 +241,7 @@ var CssAnimator = (function () {
       }
 
       classList.add('au-leave');
+      var prevAnimationNames = _this5._getElementAnimationNames(element);
 
       var animStart = undefined;
       _this5._addMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart = function (evAnimStart) {
@@ -218,16 +251,12 @@ var CssAnimator = (function () {
 
         evAnimStart.stopPropagation();
 
-        _this5._addAnimationToStack(animId);
-
         var animEnd = undefined;
         _this5._addMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd = function (evAnimEnd) {
           evAnimEnd.stopPropagation();
 
           classList.remove('au-leave-active');
           classList.remove('au-leave');
-
-          _this5._removeAnimationFromStack(animId);
 
           evAnimEnd.target.removeEventListener(evAnimEnd.type, animEnd);
 
@@ -247,6 +276,16 @@ var CssAnimator = (function () {
       var parent = element.parentElement;
       var delay = 0;
 
+      var cleanupAnimation = function cleanupAnimation() {
+        var animationNames = _this5._getElementAnimationNames(element);
+        if (!_this5._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
+          classList.remove('au-leave-active');
+          classList.remove('au-leave');
+          _this5._triggerDOMEvent(_aureliaTemplating.animationEvent.leaveTimeout, element);
+          resolve(false);
+        }
+      };
+
       if (parent !== null && parent !== undefined && (parent.classList.contains('au-stagger') || parent.classList.contains('au-stagger-leave'))) {
         var elemPos = Array.prototype.indexOf.call(parent.childNodes, element);
         delay = _this5._getElementAnimationDelay(parent) * elemPos;
@@ -255,21 +294,12 @@ var CssAnimator = (function () {
 
         setTimeout(function () {
           classList.add('au-leave-active');
+          cleanupAnimation();
         }, delay);
       } else {
         classList.add('au-leave-active');
+        cleanupAnimation();
       }
-
-      setTimeout(function () {
-        if (_this5.animationStack.indexOf(animId) < 0) {
-          classList.remove('au-leave-active');
-          classList.remove('au-leave');
-
-          _this5._triggerDOMEvent(_aureliaTemplating.animationEvent.leaveTimeout, element);
-
-          resolve(false);
-        }
-      }, _this5._getElementAnimationDelay(element) + _this5.animationTimeout + delay);
     });
   };
 
@@ -293,6 +323,7 @@ var CssAnimator = (function () {
       var animId = element.toString() + className + Math.random();
 
       classList.remove(className);
+      var prevAnimationNames = _this6._getElementAnimationNames(element);
 
       var animStart = undefined;
       _this6._addMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart = function (evAnimStart) {
@@ -304,15 +335,11 @@ var CssAnimator = (function () {
 
         evAnimStart.stopPropagation();
 
-        _this6._addAnimationToStack(animId);
-
         var animEnd = undefined;
         _this6._addMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd = function (evAnimEnd) {
           evAnimEnd.stopPropagation();
 
           classList.remove(className + '-remove');
-
-          _this6._removeAnimationFromStack(animId);
 
           evAnimEnd.target.removeEventListener(evAnimEnd.type, animEnd);
 
@@ -330,18 +357,17 @@ var CssAnimator = (function () {
 
       classList.add(className + '-remove');
 
-      setTimeout(function () {
-        if (_this6.animationStack.indexOf(animId) < 0) {
-          classList.remove(className + '-remove');
-          classList.remove(className);
+      var animationNames = _this6._getElementAnimationNames(element);
+      if (!_this6._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
+        classList.remove(className + '-remove');
+        classList.remove(className);
 
-          if (suppressEvents !== true) {
-            _this6._triggerDOMEvent(_aureliaTemplating.animationEvent.removeClassTimeout, element);
-          }
-
-          resolve(false);
+        if (suppressEvents !== true) {
+          _this6._triggerDOMEvent(_aureliaTemplating.animationEvent.removeClassTimeout, element);
         }
-      }, _this6._getElementAnimationDelay(element) + _this6.animationTimeout);
+
+        resolve(false);
+      }
     });
   };
 
@@ -368,8 +394,6 @@ var CssAnimator = (function () {
 
         evAnimStart.stopPropagation();
 
-        _this7._addAnimationToStack(animId);
-
         var animEnd = undefined;
         _this7._addMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd = function (evAnimEnd) {
           evAnimEnd.stopPropagation();
@@ -377,8 +401,6 @@ var CssAnimator = (function () {
           classList.add(className);
 
           classList.remove(className + '-add');
-
-          _this7._removeAnimationFromStack(animId);
 
           evAnimEnd.target.removeEventListener(evAnimEnd.type, animEnd);
 
@@ -394,20 +416,21 @@ var CssAnimator = (function () {
         evAnimStart.target.removeEventListener(evAnimStart.type, animStart);
       }, false);
 
+      var prevAnimationNames = _this7._getElementAnimationNames(element);
+
       classList.add(className + '-add');
 
-      setTimeout(function () {
-        if (_this7.animationStack.indexOf(animId) < 0) {
-          classList.remove(className + '-add');
-          classList.add(className);
+      var animationNames = _this7._getElementAnimationNames(element);
+      if (!_this7._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
+        classList.remove(className + '-add');
+        classList.add(className);
 
-          if (suppressEvents !== true) {
-            _this7._triggerDOMEvent(_aureliaTemplating.animationEvent.addClassTimeout, element);
-          }
-
-          resolve(false);
+        if (suppressEvents !== true) {
+          _this7._triggerDOMEvent(_aureliaTemplating.animationEvent.addClassTimeout, element);
         }
-      }, _this7._getElementAnimationDelay(element) + _this7.animationTimeout);
+
+        resolve(false);
+      }
     });
   };
 

--- a/dist/system/aurelia-animator-css.js
+++ b/dist/system/aurelia-animator-css.js
@@ -27,33 +27,18 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
         function CssAnimator() {
           _classCallCheck(this, CssAnimator);
 
-          this.animationStack = [];
-
           this.useAnimationDoneClasses = false;
           this.animationEnteredClass = 'au-entered';
           this.animationLeftClass = 'au-left';
           this.isAnimating = false;
 
-          this.animationTimeout = 50;
+          this.verifyKeyframesExist = true;
         }
 
         CssAnimator.prototype._addMultipleEventListener = function _addMultipleEventListener(el, s, fn) {
           var evts = s.split(' ');
           for (var i = 0, ii = evts.length; i < ii; ++i) {
             el.addEventListener(evts[i], fn, false);
-          }
-        };
-
-        CssAnimator.prototype._addAnimationToStack = function _addAnimationToStack(animId) {
-          if (this.animationStack.indexOf(animId) < 0) {
-            this.animationStack.push(animId);
-          }
-        };
-
-        CssAnimator.prototype._removeAnimationFromStack = function _removeAnimationFromStack(animId) {
-          var idx = this.animationStack.indexOf(animId);
-          if (idx > -1) {
-            this.animationStack.splice(idx, 1);
           }
         };
 
@@ -76,6 +61,24 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
           delay = Number(delay.replace(/[^\d\.]/g, ''));
 
           return delay * 1000;
+        };
+
+        CssAnimator.prototype._getElementAnimationNames = function _getElementAnimationNames(element) {
+          var styl = DOM.getComputedStyle(element);
+          var prefix = undefined;
+
+          if (styl.getPropertyValue('animation-name')) {
+            prefix = '';
+          } else if (styl.getPropertyValue('-webkit-animation-name')) {
+            prefix = '-webkit-';
+          } else if (styl.getPropertyValue('-moz-animation-name')) {
+            prefix = '-moz-';
+          } else {
+            return [];
+          }
+
+          var animationNames = styl.getPropertyValue(prefix + 'animation-name');
+          return animationNames ? animationNames.split(' ') : [];
         };
 
         CssAnimator.prototype._performSingleAnimate = function _performSingleAnimate(element, className) {
@@ -101,6 +104,37 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
         CssAnimator.prototype._triggerDOMEvent = function _triggerDOMEvent(eventType, element) {
           var evt = DOM.createCustomEvent(eventType, { bubbles: true, cancelable: true, detail: element });
           DOM.dispatchEvent(evt);
+        };
+
+        CssAnimator.prototype._animationChangeWithValidKeyframe = function _animationChangeWithValidKeyframe(animationNames, prevAnimationNames) {
+          var newAnimationNames = animationNames.filter(function (name) {
+            return prevAnimationNames.indexOf(name) === -1;
+          });
+
+          if (newAnimationNames.length === 0) {
+            return false;
+          }
+
+          if (!this.verifyKeyframesExist) {
+            return true;
+          }
+
+          var keyframesRuleType = window.CSSRule.KEYFRAMES_RULE || window.CSSRule.MOZ_KEYFRAMES_RULE || window.CSSRule.WEBKIT_KEYFRAMES_RULE;
+
+          var styleSheets = document.styleSheets;
+          for (var i = 0; i < styleSheets.length; ++i) {
+            var cssRules = styleSheets[i].cssRules;
+
+            for (var j = 0; j < cssRules.length; ++j) {
+              var cssRule = cssRules[j];
+
+              if (cssRule.type === keyframesRuleType) {
+                if (newAnimationNames.indexOf(cssRule.name) !== -1) return true;
+              }
+            }
+          }
+
+          return false;
         };
 
         CssAnimator.prototype.animate = function animate(element, className) {
@@ -144,6 +178,7 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
             }
 
             classList.add('au-enter');
+            var prevAnimationNames = _this4._getElementAnimationNames(element);
 
             var animStart = undefined;
             _this4._addMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart = function (evAnimStart) {
@@ -153,16 +188,12 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
 
               evAnimStart.stopPropagation();
 
-              _this4._addAnimationToStack(animId);
-
               var animEnd = undefined;
               _this4._addMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd = function (evAnimEnd) {
                 evAnimEnd.stopPropagation();
 
                 classList.remove('au-enter-active');
                 classList.remove('au-enter');
-
-                _this4._removeAnimationFromStack(animId);
 
                 evAnimEnd.target.removeEventListener(evAnimEnd.type, animEnd);
 
@@ -182,6 +213,16 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
             var parent = element.parentElement;
             var delay = 0;
 
+            var cleanupAnimation = function cleanupAnimation() {
+              var animationNames = _this4._getElementAnimationNames(element);
+              if (!_this4._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
+                classList.remove('au-enter-active');
+                classList.remove('au-enter');
+                _this4._triggerDOMEvent(animationEvent.enterTimeout, element);
+                resolve(false);
+              }
+            };
+
             if (parent !== null && parent !== undefined && (parent.classList.contains('au-stagger') || parent.classList.contains('au-stagger-enter'))) {
               var elemPos = Array.prototype.indexOf.call(parent.childNodes, element);
               delay = _this4._getElementAnimationDelay(parent) * elemPos;
@@ -190,21 +231,12 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
 
               setTimeout(function () {
                 classList.add('au-enter-active');
+                cleanupAnimation();
               }, delay);
             } else {
               classList.add('au-enter-active');
+              cleanupAnimation();
             }
-
-            setTimeout(function () {
-              if (_this4.animationStack.indexOf(animId) < 0) {
-                classList.remove('au-enter-active');
-                classList.remove('au-enter');
-
-                _this4._triggerDOMEvent(animationEvent.enterTimeout, element);
-
-                resolve(false);
-              }
-            }, _this4._getElementAnimationDelay(element) + _this4.animationTimeout + delay);
           });
         };
 
@@ -223,6 +255,7 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
             }
 
             classList.add('au-leave');
+            var prevAnimationNames = _this5._getElementAnimationNames(element);
 
             var animStart = undefined;
             _this5._addMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart = function (evAnimStart) {
@@ -232,16 +265,12 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
 
               evAnimStart.stopPropagation();
 
-              _this5._addAnimationToStack(animId);
-
               var animEnd = undefined;
               _this5._addMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd = function (evAnimEnd) {
                 evAnimEnd.stopPropagation();
 
                 classList.remove('au-leave-active');
                 classList.remove('au-leave');
-
-                _this5._removeAnimationFromStack(animId);
 
                 evAnimEnd.target.removeEventListener(evAnimEnd.type, animEnd);
 
@@ -261,6 +290,16 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
             var parent = element.parentElement;
             var delay = 0;
 
+            var cleanupAnimation = function cleanupAnimation() {
+              var animationNames = _this5._getElementAnimationNames(element);
+              if (!_this5._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
+                classList.remove('au-leave-active');
+                classList.remove('au-leave');
+                _this5._triggerDOMEvent(animationEvent.leaveTimeout, element);
+                resolve(false);
+              }
+            };
+
             if (parent !== null && parent !== undefined && (parent.classList.contains('au-stagger') || parent.classList.contains('au-stagger-leave'))) {
               var elemPos = Array.prototype.indexOf.call(parent.childNodes, element);
               delay = _this5._getElementAnimationDelay(parent) * elemPos;
@@ -269,21 +308,12 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
 
               setTimeout(function () {
                 classList.add('au-leave-active');
+                cleanupAnimation();
               }, delay);
             } else {
               classList.add('au-leave-active');
+              cleanupAnimation();
             }
-
-            setTimeout(function () {
-              if (_this5.animationStack.indexOf(animId) < 0) {
-                classList.remove('au-leave-active');
-                classList.remove('au-leave');
-
-                _this5._triggerDOMEvent(animationEvent.leaveTimeout, element);
-
-                resolve(false);
-              }
-            }, _this5._getElementAnimationDelay(element) + _this5.animationTimeout + delay);
           });
         };
 
@@ -307,6 +337,7 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
             var animId = element.toString() + className + Math.random();
 
             classList.remove(className);
+            var prevAnimationNames = _this6._getElementAnimationNames(element);
 
             var animStart = undefined;
             _this6._addMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart = function (evAnimStart) {
@@ -318,15 +349,11 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
 
               evAnimStart.stopPropagation();
 
-              _this6._addAnimationToStack(animId);
-
               var animEnd = undefined;
               _this6._addMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd = function (evAnimEnd) {
                 evAnimEnd.stopPropagation();
 
                 classList.remove(className + '-remove');
-
-                _this6._removeAnimationFromStack(animId);
 
                 evAnimEnd.target.removeEventListener(evAnimEnd.type, animEnd);
 
@@ -344,18 +371,17 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
 
             classList.add(className + '-remove');
 
-            setTimeout(function () {
-              if (_this6.animationStack.indexOf(animId) < 0) {
-                classList.remove(className + '-remove');
-                classList.remove(className);
+            var animationNames = _this6._getElementAnimationNames(element);
+            if (!_this6._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
+              classList.remove(className + '-remove');
+              classList.remove(className);
 
-                if (suppressEvents !== true) {
-                  _this6._triggerDOMEvent(animationEvent.removeClassTimeout, element);
-                }
-
-                resolve(false);
+              if (suppressEvents !== true) {
+                _this6._triggerDOMEvent(animationEvent.removeClassTimeout, element);
               }
-            }, _this6._getElementAnimationDelay(element) + _this6.animationTimeout);
+
+              resolve(false);
+            }
           });
         };
 
@@ -382,8 +408,6 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
 
               evAnimStart.stopPropagation();
 
-              _this7._addAnimationToStack(animId);
-
               var animEnd = undefined;
               _this7._addMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd = function (evAnimEnd) {
                 evAnimEnd.stopPropagation();
@@ -391,8 +415,6 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
                 classList.add(className);
 
                 classList.remove(className + '-add');
-
-                _this7._removeAnimationFromStack(animId);
 
                 evAnimEnd.target.removeEventListener(evAnimEnd.type, animEnd);
 
@@ -408,20 +430,21 @@ System.register(['aurelia-templating', 'aurelia-pal'], function (_export) {
               evAnimStart.target.removeEventListener(evAnimStart.type, animStart);
             }, false);
 
+            var prevAnimationNames = _this7._getElementAnimationNames(element);
+
             classList.add(className + '-add');
 
-            setTimeout(function () {
-              if (_this7.animationStack.indexOf(animId) < 0) {
-                classList.remove(className + '-add');
-                classList.add(className);
+            var animationNames = _this7._getElementAnimationNames(element);
+            if (!_this7._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
+              classList.remove(className + '-add');
+              classList.add(className);
 
-                if (suppressEvents !== true) {
-                  _this7._triggerDOMEvent(animationEvent.addClassTimeout, element);
-                }
-
-                resolve(false);
+              if (suppressEvents !== true) {
+                _this7._triggerDOMEvent(animationEvent.addClassTimeout, element);
               }
-            }, _this7._getElementAnimationDelay(element) + _this7.animationTimeout);
+
+              resolve(false);
+            }
           });
         };
 

--- a/test/animate.spec.js
+++ b/test/animate.spec.js
@@ -14,44 +14,63 @@ describe('animator-css', () => {
     var elem,
         testClass;
 
-    beforeEach(() => {
-      loadFixtures('animate.html');
-      elem      = $('#animateAddAndRemove').eq(0)[0];
-      testClass = 'animate-test';
-    });
-
-    it('should add and remove a class automatically', (done) => {
-      sut.animate(elem, testClass).then(() => {
-        expect(sut.animationStack.length).toBe(0);
-        expect($('#animateAddAndRemove').eq(0).css('opacity')).toBe('0');
-        done();
+    describe('with valid keyframes', () => {
+      beforeEach(() => {
+        loadFixtures('animate.html');
+        elem      = $('#animateAddAndRemove').eq(0)[0];
+        testClass = 'animate-test';
       });
-    });
 
-    it('should animate multiple elements', (done) => {
-      var elements = $('.sequenced-items li');
-
-      sut.animate([elements.eq(0)[0], elements.eq(1)[0], elements.eq(2)[0]], testClass).then(() => {
-        expect(sut.animationStack.length).toBe(0);
-        expect(elements.eq(0).css('opacity')).toBe('1');
-        expect(elements.eq(1).css('opacity')).toBe('1');
-        expect(elements.eq(2).css('opacity')).toBe('1');
-        done();
+      it('should add and remove a class automatically', (done) => {
+        sut.animate(elem, testClass).then(() => {
+          expect(sut.isAnimating).toBe(false);
+          expect($('#animateAddAndRemove').eq(0).css('opacity')).toBe('0');
+          done();
+        });
       });
-    });
 
-    it('should not fire add/remove events', (done) => {
-      var eventCalled = false
-        , listenerAdd = document.addEventListener(animationEvent.addClassBegin, () => eventCalled = true)
-        , listenerRemove = document.addEventListener(animationEvent.removeClassBegin, () => eventCalled = true);
+      it('should animate multiple elements', (done) => {
+        var elements = $('.sequenced-items li');
 
-      sut.animate(elem, testClass).then(() => {
-        expect(eventCalled).toBe(false);
-
-        document.removeEventListener(animationEvent.addClassBegin, listenerAdd);
-        document.removeEventListener(animationEvent.removeClassBegin, listenerRemove);
-        done();
+        sut.animate([elements.eq(0)[0], elements.eq(1)[0], elements.eq(2)[0]], testClass).then(() => {
+          expect(sut.isAnimating).toBe(false);
+          expect(elements.eq(0).css('opacity')).toBe('1');
+          expect(elements.eq(1).css('opacity')).toBe('1');
+          expect(elements.eq(2).css('opacity')).toBe('1');
+          done();
+        });
       });
-    });
+
+      it('should not fire add/remove events', (done) => {
+        var eventCalled = false
+          , listenerAdd = document.addEventListener(animationEvent.addClassBegin, () => eventCalled = true)
+          , listenerRemove = document.addEventListener(animationEvent.removeClassBegin, () => eventCalled = true);
+
+        sut.animate(elem, testClass).then(() => {
+          expect(eventCalled).toBe(false);
+
+          document.removeEventListener(animationEvent.addClassBegin, listenerAdd);
+          document.removeEventListener(animationEvent.removeClassBegin, listenerRemove);
+          done();
+        });
+      });
+    })
+
+    // missing keyframes currently break the promise animator
+    describe('without valid keyframes', () => {
+      beforeEach(() => {
+        loadFixtures('animate-missing-keyframes.html');
+        elem      = $('#animateAddAndRemove').eq(0)[0];
+        testClass = 'animate-test';
+      });
+
+      it('should add and remove a class automatically', (done) => {
+        sut.animate(elem, testClass).then(() => {
+          expect(sut.isAnimating).toBe(false);
+          expect($('#animateAddAndRemove').eq(0).css('opacity')).toBe('0');
+          done();
+        });
+      });
+    })
   });
 });

--- a/test/animator.spec.js
+++ b/test/animator.spec.js
@@ -71,7 +71,7 @@ describe('animator-css', () => {
       var elem = $('.animated-item').eq(0)[0];
 
       sut.enter(elem).then( () => {
-        expect(sut.animationStack.length).toBe(0);
+        expect(sut.isAnimating).toBe(false);
         done();
       });
     });
@@ -80,7 +80,7 @@ describe('animator-css', () => {
       var elem = $('#delayedElement').eq(0)[0];
 
       sut.enter(elem).then( () => {
-        expect(sut.animationStack.length).toBe(0);
+        expect(sut.isAnimating).toBe(false);
         done();
       });
     });
@@ -213,7 +213,7 @@ describe('animator-css', () => {
 
     it('should remove animation from stack after done', (done) => {
       var result = sut.leave(elem).then( () => {
-        expect(sut.animationStack.length).toBe(0);
+        expect(sut.isAnimating).toBe(false);
         done();
       });
     });
@@ -348,7 +348,7 @@ describe('animator-css', () => {
 
     it('should remove animation from stack after done', (done) => {
       var result = sut.removeClass(elem, testClass).then( () => {
-        expect(sut.animationStack.length).toBe(0);
+        expect(sut.isAnimating).toBe(false);
         done();
       });
     });
@@ -437,7 +437,7 @@ describe('animator-css', () => {
 
     it('should remove animation from stack after done', (done) => {
       var result = sut.addClass(elem, testClass).then( () => {
-        expect(sut.animationStack.length).toBe(0);
+        expect(sut.isAnimating).toBe(false);
         done();
       });
     });

--- a/test/fixtures/animate-missing-keyframes.html
+++ b/test/fixtures/animate-missing-keyframes.html
@@ -1,22 +1,7 @@
 <style type="text/css">
-  @keyframes hide-animation {
-    from { opacity: 1; }
-    to { opacity: 0; }
+  #animateAddAndRemove {
+    opacity: 0;
   }
-  @-webkit-keyframes hide-animation{
-    from { opacity: 1; }
-    to { opacity: 0; }
-  }
-
-  @keyframes show-animation {
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }
-  @-webkit-keyframes show-animation{
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }
-
   .animate-test {
     opacity: 1;
   }
@@ -32,6 +17,8 @@
 </style>
 
 <div id="animation">
+  <div id="animateAddAndRemove">Animation - automatic add/remove</div>
+
   <ul class="sequenced-items">
     <li class="au-animate">Sequence 1</li>
     <li class="au-animate">Sequence 2</li>

--- a/test/fixtures/animate.html
+++ b/test/fixtures/animate.html
@@ -1,4 +1,22 @@
 <style type="text/css">
+  @keyframes hide-animation {
+    from { opacity: 1; }
+    to { opacity: 0; }
+  }
+  @-webkit-keyframes hide-animation{
+    from { opacity: 1; }
+    to { opacity: 0; }
+  }
+
+  @keyframes show-animation {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  @-webkit-keyframes show-animation{
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
   #animateAddAndRemove {
     opacity: 0;
   }


### PR DESCRIPTION
Fixes the issue described in https://github.com/aurelia/animator-css/issues/28.

Rather than using a timeout which is subject to race conditions, this checks if the computed property for `animation`/`-webkit-animation` has changed between `au-enter` and `au-enter-active` (or equivalents).