### PR TITLE
fix(cssRules): add additional try/catch

### DIFF
--- a/src/animator.js
+++ b/src/animator.js
@@ -153,7 +153,13 @@ export class CssAnimator {
 
     try {
       for (let i = 0; i < styleSheets.length; ++i) {
-        let cssRules = styleSheets[i].cssRules;
+        let cssRules = null;
+
+        try {
+          cssRules = styleSheets[i].cssRules;
+        } catch (e) {
+          // do nothing
+        }
 
         if (!cssRules) {
           continue;


### PR DESCRIPTION
Fixed a bug where FireFox would throw a security exception when trying to access the css rules from a stylesheet loaded from a 3rd party server (Think CDN). This exception would stop Aurelia CSS animations from running and instead just snap. The update tries to read the rules and if it fails it continues on with the loop, where previously it would terminate the loop and always return a false result.

addition to fix for issue #40