### PR TITLE
fix(CssAnimator): clear event handlers when there's no animation

### DIFF
--- a/src/animator.js
+++ b/src/animator.js
@@ -38,6 +38,20 @@ export class CssAnimator {
   }
 
   /**
+   * Remove multiple listeners at once from the given element
+   *
+   * @param el the element
+   * @param s  collection of events to remove
+   * @param fn callback to remove
+   */
+  _removeMultipleEventListener(el: HTMLElement, s: string, fn: Function) : void {
+    let evts = s.split(' ');
+    for (let i = 0, ii = evts.length; i < ii; ++i) {
+      el.removeEventListener(evts[i], fn, false);
+    }
+  }
+
+  /**
    * Vendor-prefix save method to get the animation-delay
    *
    * @param element the element to inspect
@@ -291,6 +305,10 @@ export class CssAnimator {
         if (! this._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
           classList.remove('au-enter-active');
           classList.remove('au-enter');
+
+          this._removeMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd);
+          this._removeMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart);
+
           this._triggerDOMEvent(animationEvent.enterTimeout, element);
           resolve(false);
         }
@@ -395,6 +413,10 @@ export class CssAnimator {
         if (! this._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
           classList.remove('au-leave-active');
           classList.remove('au-leave');
+
+          this._removeMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd);
+          this._removeMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart);
+
           this._triggerDOMEvent(animationEvent.leaveTimeout, element);
           resolve(false);
         }
@@ -498,6 +520,9 @@ export class CssAnimator {
         classList.remove(className + '-remove');
         classList.remove(className);
 
+        this._removeMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd);
+        this._removeMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart);
+
         if (suppressEvents !== true) {
           this._triggerDOMEvent(animationEvent.removeClassTimeout, element);
         }
@@ -577,6 +602,9 @@ export class CssAnimator {
       if (! this._animationChangeWithValidKeyframe(animationNames, prevAnimationNames)) {
         classList.remove(className + '-add');
         classList.add(className);
+
+        this._removeMultipleEventListener(element, 'webkitAnimationEnd animationend', animEnd);
+        this._removeMultipleEventListener(element, 'webkitAnimationStart animationstart', animStart);
 
         if (suppressEvents !== true) {
           this._triggerDOMEvent(animationEvent.addClassTimeout, element);

--- a/test/animator.spec.js
+++ b/test/animator.spec.js
@@ -537,6 +537,29 @@ describe('animator-css', () => {
     });
   });
 
+  describe('event listener cleanup', () => {
+
+    let el, testClass;
+
+    beforeEach(() => {
+      loadFixtures('addremove.html');
+      el = $('#overlap').eq(0)[0];
+      sut.addClass(el, 'aurelia-hide');
+    });
+
+    it('should remove event listeners when no animation occurs', (done) => {
+      expect(el.classList.contains('fade-in')).toBe(true);
+      expect(el.classList.contains('aurelia-hide')).toBe(true);
+
+      sut.removeClass(el, 'aurelia-hide');
+      setTimeout(function() {
+        expect(el.classList.contains('fade-in')).toBe(true);
+        expect(el.classList.contains('aurelia-hide')).toBe(false);
+        done();
+      }, 2000);
+    });
+  });
+
   describe('staggering animations', () => {
     var elems;
 

--- a/test/fixtures/addremove.html
+++ b/test/fixtures/addremove.html
@@ -27,6 +27,13 @@
     animation:0.2s show-animation;
   }
 
+  .aurelia-hide { 
+    display: none !important;
+  }
+  .fade-in { 
+    animation: show-animation 1s;
+    -webkit-animation: show-animation 1s;
+  }
 </style>
 
 <div>
@@ -34,3 +41,5 @@
     Quickly animated element
   </span>
 </div>
+
+<div id="overlap" class="fade-in au-animate aurelia-hide">Clean up</div>


### PR DESCRIPTION
Event handlers were not being removed in addClass & removeClass. This was causing problems when paired with the show attribute.

fixes #47