### PR TITLE
Fix for addClass/removeClass race condition affecting show.bind

### DIFF
--- a/test/fixtures/addremove.html
+++ b/test/fixtures/addremove.html
@@ -17,12 +17,12 @@
     to { opacity: 1; }
   }
   
-  .animate-hide-add {
+  .aurelia-hide-add {
     -webkit-animation:0.2s show-animation;
     animation:0.2s show-animation;
   }
   
-  .animate-hide-remove {
+  .aurelia-hide-remove {
     -webkit-animation:0.2s show-animation;
     animation:0.2s show-animation;
   }


### PR DESCRIPTION
This fixes the race condition reported in #54 . There was a unit test for this specific scenario, however it was reporting a false positive because the CSS was using an incorrect name - in the actual execution of the test the animation wasn't used at all. Fixing the unit test reported an error on the original code. I then applied my fixes and the unit test began to pass. I've also tested the changes in my own project with various animation durations on add/remove.

Based on a discussion I saw with JODS and another maintainer (I think in templating github to do with ELSE implementation) I see that we want to prematurely end an animation instead of chaining them, so my changes include this which probably helps the race conditions as well. Developers can use the promises returned by the add/remove class to ensure the animations are chained instead if they want.

Here's a basic timeline of the add/remove overlap scenario before the fix:

`addClass()`  animation start:
- `class-add` added

50ms delay

removeClass() animation start:

- `class-remove` added
		
current state: `class-remove` + `class-add` applied to element.

`addClass()` animation end callback:
- `class` added
- `class-add` removed

`removeClass()` animation end callback:
- `class-remove` removed

current state: `class` is applied because of the `addClass()` end animation callback, but shouldn't be.